### PR TITLE
Update slicer_nw

### DIFF
--- a/slicer_nw
+++ b/slicer_nw
@@ -53,7 +53,7 @@ if [ -n "$overlaycmd" ]; then
     overlay $overlaycmd
 fi
     
-    overlay 0 0 t2_unbiased -a lesionmapT2 0.9 1.1  lesionmapT2 0.9 1.1 overlay
+    overlay 0 0 T2_unbiased -a lesionmapT2 0.9 1.1  lesionmapT2 0.9 1.1 overlay
     
     midx=$(fslstats $in -C | cut -d" " -f1 | cut -d"." -f1)
     for it in {1..18}; do


### PR DESCRIPTION
There was a capitalization issue on T2_unbiased instead being typed as t2_unbiased. This made the script crash on case sensitive platforms.